### PR TITLE
Allow CORS headers to be overwritten

### DIFF
--- a/includes/api/class-endpoint-api.php
+++ b/includes/api/class-endpoint-api.php
@@ -342,11 +342,13 @@ class Endpoint_Api {
 			$last_error = json_last_error();
 
 			if ( JSON_ERROR_NONE === $last_error ) {
+
+				$this->rest_send_cors_headers( '' );
+				
 				foreach ( $cache['headers'] as $key => $value ) {
 					$header = sprintf( '%s: %s', $key, $value );
 					header( $header );
 				}
-				$this->rest_send_cors_headers( '' );
 
 				echo $data; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				exit;


### PR DESCRIPTION
When the response is served from a CDN, the headers are also cached there.

If your REST API is consumed by more than one origin, the logic to set the `Access-Control-Allow-Origin` on the fly doesn't work, because only one of the origins is cached in the CDN and the rest fail:

https://github.com/acato-plugins/wp-rest-cache/blob/5f77424dad3c2149fd43988aa6233adc4d6095b1/includes/api/class-endpoint-api.php#L377

Origins consuming the REST API:

- `domain1.com`
- `domain2.com`
- `domain3.com`

Headers generated by the REST Cache:

- `Access-Control-Allow-Origin`: `domain1.com`
- `Access-Control-Allow-Origin`: `domain2.com`
- `Access-Control-Allow-Origin`: `domain3.com`

Only one header cached by the CDN, whichever comes first:

- `Access-Control-Allow-Origin`: `domain1.com` (for example)

Final CORS in the browser:

- `domain1.com`: It works.
- `domain2.com`: It doesn't work.
- `domain3.com`: It doesn't work.

I know this is the default behavior of the REST API itself, but it can be overwritten like shown here: https://github.com/ahmadawais/WP-REST-Allow-All-CORS/blob/master/plugin.php

This PR writes those CORS first and then restores the headers saved in the original response, allowing them to be overwritten.