### PR TITLE
Add batch queries support to improve performance and handle row limitations

### DIFF
--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP REST Cache
  * Plugin URI:        https://www.acato.nl
  * Description:       Adds caching to the WP REST API
- * Version:           2025.1.7
+ * Version:           2025.1.8
  * Author:            Acato
  * Author URI:        https://www.acato.nl
  * Text Domain:       wp-rest-cache


### PR DESCRIPTION
This pull request introduces batch query logic to the WP REST Cache plugin. The goal is to enhance query performance and ensure compatibility with environments that impose per-query row limits (e.g., PlanetScale, which limits rows returned, updated, or deleted to 100k).

Changes included
	•	Implemented batch queries to split large database operations into smaller chunks.
	•	Ensures queries respect per-query row limitations imposed by some database environments.
	•	Improved performance for large datasets by processing queries in batches.
	•	Added safeguards to maintain data consistency during batched operations.

Benefits
	•	Prevents query failures in environments with strict row limits.
	•	Improves stability and compatibility with cloud-hosted databases (e.g., PlanetScale).
	•	Enhances performance for large-scale cache operations.

Notes
	•	Backward compatible — existing installations will continue to function without configuration changes.
	•	Tested with large datasets to validate performance improvements and stability.