### PR TITLE
Modify transition_post_status logic for caching

### DIFF
--- a/includes/caching/class-caching.php
+++ b/includes/caching/class-caching.php
@@ -357,7 +357,7 @@ class Caching {
 
 	/**
 	 * Fired upon WordPress 'transition_post_status' hook. Delete all non-single endpoint caches for this post type if
-	 * the new or the old status is 'publish'.
+	 * the new or the old status (but not both) is 'publish'.
 	 *
 	 * @param string   $new_status The new status of the post.
 	 * @param string   $old_status The old status of the post.
@@ -366,7 +366,7 @@ class Caching {
 	 * @return void
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
-		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+		if ( $new_status === $old_status || ( 'publish' !== $new_status && 'publish' !== $old_status ) ) {
 			return;
 		}
 

--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP REST Cache
  * Plugin URI:        https://www.acato.nl
  * Description:       Adds caching to the WP REST API
- * Version:           2026.1.0
+ * Version:           2026.1.1
  * Author:            Acato
  * Author URI:        https://www.acato.nl
  * Text Domain:       wp-rest-cache


### PR DESCRIPTION
Update condition to check if post status has actually changed to 'publish', as `transition_post_status` runs on every save
