### PR TITLE
Add support for flushing term cache when objects terms are modified

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -163,6 +163,7 @@ class Plugin {
 		add_action( 'edited_term', [ $caching, 'edited_term' ], 999, 3 );
 		add_action( 'delete_term', [ $caching, 'delete_term' ], 10, 3 );
 		add_action( 'updated_term_meta', [ $caching, 'updated_term_meta' ], 10, 4 );
+		add_action( 'set_object_terms', [ $caching, 'set_object_terms' ], 10, 6 );
 
 		add_action( 'profile_update', [ $caching, 'profile_update' ], 999 );
 		add_action( 'user_register', [ $caching, 'user_register' ], 999 );

--- a/wp-rest-cache.php
+++ b/wp-rest-cache.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP REST Cache
  * Plugin URI:        https://www.acato.nl
  * Description:       Adds caching to the WP REST API
- * Version:           2026.1.1
+ * Version:           2026.1.2
  * Author:            Acato
  * Author URI:        https://www.acato.nl
  * Text Domain:       wp-rest-cache


### PR DESCRIPTION
As of now, lets say i query
`/wp-json/wp/v2/categories`
I get back the count for each category (and by default it also hides empty categories).

If I add a post or edit a posts category, the counts should change, but they don't.

So I added function to hook into `set_object_terms`.

I added the filter `wp_rest_cache/flush_on_set_terms` and defaulted it to `false` for performance, as the function is quite heavy, it has to do the following

- Get term ids from taxonomy ids
- Get all term ids for object
- Get all parent term ids if the taxonomy is hierarchical
- Loop over each affected term (including ancestors) and clear related caches